### PR TITLE
Made the lexer more unicode friendly.

### DIFF
--- a/core/read.rkt
+++ b/core/read.rkt
@@ -25,20 +25,18 @@
                       end-of-line-comment])
 
 (define-lex-abbrev digit (:/ #\0 #\9))
-(define-lex-abbrev identifier-first-character (:or (:/ #\a #\z)
-                                                   (:/ #\A #\Z)
+(define-lex-abbrev identifier-first-character (:or alphabetic
                                                    "_" "?"))
 (define-lex-abbrev identifier-character (:or identifier-first-character
-                                             digit))
+                                             numeric))
 (define-lex-abbrev identifier (:: identifier-first-character
                                   (:* identifier-character)))
 (define-lex-abbrev number (:: (:+ digit) (:? (:: "." (:+ digit)))))
 (define-lex-abbrev string-character (:or (:: #\\ any-char)
                                          (:~ #\")))
-(define-lex-abbrev string (:: #\" (:* string-character) #\"))
-(define-lex-abbrev operator (:or "+=" "-=" "*=" "/="
-                                 "+" "!=" "=>" "=" "==" "*" "/" "-" "^" "||" "|" "&&" "<="
-                                 ">=" "<-" "<" ">" "!" "::" ":=" "%"))
+(define-lex-abbrev string (:: #\" (:* string-character) #\")) 
+(define-lex-abbrev operator (:or "+=" "-=" "*=" "/=" "!=" "=>" "==" "||" "&&" "<="
+                                 ">=" "<-" "!" "::" ":=" "%" symbolic))
 (define-lex-abbrev block-comment (:: "/*"
                                      (complement (:: any-string "*/" any-string))
                                      "*/"))


### PR DESCRIPTION
Self explanatory, but 
1. Lets identifiers use any char-alphabetic? instead of [A-Z|a-z]
2. Lets identifiers use subscript and superscript chars (or any other char-numeric?)
3. Allows any char-symbolic? as an operator.
