### PR TITLE
Honu operators can now be used normally in Racket.

### DIFF
--- a/enforest/arithmetic.rkt
+++ b/enforest/arithmetic.rkt
@@ -1,0 +1,19 @@
+#lang racket/base
+(require (for-syntax racket/base))
+
+(require "./main.rkt")
+
+(define-unary+binary-operator add 1 'left +)
+(define-unary+binary-operator sub 1 'left -)
+(define-binary-operator mult 2 'left *)
+(define-binary-operator div 2 'left /)
+(define-binary-operator pow 2 'right expt)
+(define-binary-operator equals 1 'left =)
+(define-binary-operator less 0.9 'left <)
+(define-binary-operator leq 0.9 'left <=)
+(define-binary-operator greater 0.9 'left >)
+(define-binary-operator geq 0.9 'left >=)
+
+(provide (rename-out [add +][sub -][mult *][div /]
+                     [pow ^][equals =][less <]
+                     [leq <=][greater >][geq >=]))

--- a/enforest/def-forms.rkt
+++ b/enforest/def-forms.rkt
@@ -27,26 +27,26 @@
      #'(define-syntax name (make-fixture transformer))]))
 
 (define-syntax-rule (define-binary-operator name precedence associativity operator)
-    (define-honu-operator/syntax name precedence associativity
-                                 ;; binary
-                                 (lambda (left right)
-                                   (with-syntax ([left left]
-                                                 [right right])
-                                     (racket-syntax (operator left right))))))
+  (define-honu-operator/syntax name precedence associativity
+    ;; binary
+    (lambda (left . right)
+      (with-syntax ([left left]
+                    [(right (... ...)) right])
+        (racket-syntax (operator left right (... ...)))) ) ))
 
 (define-syntax-rule (define-unary+binary-operator name precedence associativity operator)
-    (define-honu-operator/syntax name precedence associativity
-                                 ;; binary
-                                 (lambda (left right)
-                                   (with-syntax ([left left]
-                                                 [right right])
-                                     (racket-syntax (operator left right))))
-                                 ;; unary
-                                 (lambda (arg)
-                                   (with-syntax ([arg arg])
-                                     (racket-syntax (operator arg))))
-                                 ;; binary operators should not be able to be postfix
-                                 #f))
+  (define-honu-operator/syntax name precedence associativity
+    ;; binary
+    (lambda (left . right)
+      (with-syntax ([left left]
+                    [(right (... ...)) right])
+        (racket-syntax (operator left right (... ...)))) )
+    ;; unary
+    (lambda (arg)
+      (with-syntax ([arg arg])
+        (racket-syntax (operator arg))))
+    ;; binary operators should not be able to be postfix
+    #f))
 
 (define-syntax-rule (define-unary-operator name precedence postfix? operator)
                     ;; associativity dont matter for unary 

--- a/enforest/literals.rkt
+++ b/enforest/literals.rkt
@@ -2,51 +2,14 @@
 
 (provide (all-defined-out))
 (require "def-forms.rkt" syntax/parse)
-#|
-(require syntax/parse
-         (for-syntax racket/base
-                     syntax/parse))
-
-;; macro for defining literal tokens that can be used in macros
-(define-syntax-rule (define-literal name ...)
-  (begin
-   (define-syntax name (lambda (stx)
-                         (raise-syntax-error 'name
-                                             "this is a literal and cannot be used outside a macro" (syntax->datum stx))))
-   ...))
-|#
-;(define-literal honu-return)
-;(define-literal semicolon)
-(define-literal
-;                honu-|| honu-%
-;                honu-%=
-;                honu-&= honu-^= honu-\|= honu-<<= honu->>= honu->>>=
-;                honu->> honu-<< honu->>> 
-;                honu-!=
-;                honu-<-
-;                honu-literal
-;                honu-then
-;                honu-?
-                ;honu-:
-                honu-comma ;honu-.
+(define-literal honu-comma
                 #%braces #%brackets #%parens %colon
                 %semicolon
                 ellipses-comma ellipses-comma* ellipses-repeat
-;                honu-in
-;                honu-where
-;                honu-for-template
-;                honu-prefix
-;                honu-rename
                 honu-$
                 ;; FIXME: in-lines should probably not be here
                 honu-in-lines
                 postfix)
-#|
-(define-syntax-rule (define-literal+set set literal ...)
-                    (begin
-                      (define-literal literal ...)
-                      (begin-for-syntax
-                        (define-literal-set set (literal ...)))))
-|#
+
 (define-literal-set cruft (#%parens #%brackets #%braces
                            %semicolon %colon honu-comma))

--- a/enforest/main.rkt
+++ b/enforest/main.rkt
@@ -5,7 +5,9 @@
          "compile.rkt"
          "literals.rkt"
          "def-forms.rkt"
-         "parse.rkt")
+         "parse.rkt"
+         "unparsed-begin.rkt")
+
 
 (provide (all-from-out
           "syntax.rkt"
@@ -13,4 +15,5 @@
           "compile.rkt"
           "def-forms.rkt"
           "literals.rkt"
-          "parse.rkt"))
+          "parse.rkt"
+          "unparsed-begin.rkt"))

--- a/enforest/syntax.rkt
+++ b/enforest/syntax.rkt
@@ -6,14 +6,6 @@
                      syntax/define)
          "def-forms.rkt")
 
-#;(provide define-honu-syntax)
-#;(define-syntax (define-honu-syntax stx)
-  (let-values ([(id rhs) (normalize-definition stx #'lambda #f)])
-    (with-syntax ([id id]
-                  [rhs rhs])
-      (syntax/loc stx
-                 (define-syntax id (make-honu-transformer rhs))))))
-
 ;; Do any honu-specific expansion here
 (require (for-syntax
            "template.rkt" ;; for compress-dollars at phase 1

--- a/enforest/transformer.rkt
+++ b/enforest/transformer.rkt
@@ -1,7 +1,8 @@
 #lang racket/base
+(require racket/syntax)
 
 
-(provide honu-transformer? make-honu-transformer)
+(provide honu-transformer? make-honu-transformer honu-trans-ref)
 
 (define-values (prop:honu-transformer honu-transformer? honu-transformer-ref)
                (make-struct-type-property 'honu-transformer))
@@ -33,7 +34,15 @@
                (make-struct-type 'honu-operator #f (length operator-fields) 0 #f 
                                  (list (list prop:honu-operator #t))
                                  (current-inspector)
-                                 0))
+                                 (λ(self stx)
+                                   (syntax-case stx ()
+                                     [(_ l)
+                                      (let ([op-fn (operator-unary-transformer self)])
+                                        (op-fn #'l))]
+                                     [(_ l r ...)
+                                      (let ([op-fn (operator-binary-transformer self)])
+                                        (apply op-fn (cons #'l (syntax->list #'(r ...)))))]
+                                     ))))
 
 (define (get n)
   (lambda (operator)

--- a/enforest/unparsed-begin.rkt
+++ b/enforest/unparsed-begin.rkt
@@ -1,0 +1,28 @@
+#lang racket/base
+(require (for-syntax macro-debugger/emit
+                     scheme/base
+                     syntax/define
+                     syntax/parse
+                     "debug.rkt"
+                     "parse.rkt")
+         (for-meta 2 racket/base)
+         (for-meta 3 racket/base)
+         "debug.rkt"
+         "parse.rkt")
+(provide unparsed-begin)
+(define-syntax (unparsed-begin stx)
+  (emit-remark "Honu unparsed begin!" stx)
+  (debug "honu unparsed begin: ~a at phase ~a\n" (syntax->datum stx) (syntax-local-phase-level))
+  (syntax-parse stx
+    [(_) #'(void)]
+    [(_ forms ...)
+     #'(begin
+         (define-syntax (parse-more stx)
+           (syntax-case stx ()
+             [(_ stuff (... ...))
+              (do-parse-rest #'(stuff (... ...)) #'parse-more)]))
+         (parse-more forms ...))
+     ;; if parsed is #f then we don't want to expand to anything that will print
+     ;; so use an empty form, begin, `parsed' could be #f becuase there was no expression
+     ;; in the input such as parsing just ";".
+     ]))

--- a/honu/core/private/literals.rkt
+++ b/honu/core/private/literals.rkt
@@ -1,10 +1,9 @@
 #lang racket/base
+(require enforest enforest/literals)
+(provide (all-defined-out)
+         (all-from-out enforest/literals))
 
-(provide (all-defined-out))
-(require enforest)
-
-(define-literal
-                honu-|| honu-%
+(define-literal honu-|| honu-%
                 honu-%=
                 honu-&= honu-^= honu-\|= honu-<<= honu->>= honu->>>=
                 honu->> honu-<< honu->>> 
@@ -14,18 +13,9 @@
                 honu-then
                 honu-?
                 honu-:
-  ;                honu-comma ;
-                 honu-.
-;                #%braces #%brackets #%parens %colon
-;                %semicolon
-;                ellipses-comma ellipses-comma* ellipses-repeat
+                honu-.
                 honu-in
                 honu-where
                 honu-for-template
                 honu-prefix
-                honu-rename
-;                honu-$
-                ;; FIXME: in-lines should probably not be here
-;                honu-in-lines
-                ;                postfix
-                )
+                honu-rename)


### PR DESCRIPTION
More can be done, but it's a start.

```
#lang racket
(require enforest
         enforest/arithmetic)

(define (f x)
  (unparsed-begin
    3 * x ^ 2 + 1 ))
(define (g x)
  (+ (* 3 (^ x 2)) 1))

(for/and ([i (in-range 1000)])
  (unparsed-begin
   g (#%parens i) = f (#%parens i)))
```
