### PR TITLE
Organizing do-parse

### DIFF
--- a/enforest/parse-utils.rkt
+++ b/enforest/parse-utils.rkt
@@ -1,0 +1,87 @@
+#lang racket/base
+
+
+(define-syntax-rule (require-syntax stuff ...)
+                    (require (for-syntax stuff ...)))
+
+;; phase 0
+(require (for-template racket/base
+                       racket/sequence
+                       "def-forms.rkt")
+         macro-debugger/emit
+         syntax/parse
+         syntax/parse/experimental/splicing
+         syntax/stx
+         "compile.rkt"
+         "debug.rkt"
+         "transformer.rkt"
+         "def-forms.rkt"
+         "literals.rkt"
+         "template.rkt")
+
+;; phase 1
+(require-syntax racket/base
+                "compile.rkt"
+                "debug.rkt")
+
+;; phase -1
+
+(provide (all-defined-out))
+(define (strip-stops code)
+  (define-syntax-class stopper #:literal-sets (cruft)
+    [pattern honu-comma]
+    [pattern %colon]) code)
+
+(define (get-value what)
+  (syntax-local-value what (lambda () #f)))
+
+
+(define (bound-to-operator? check)
+  (let ([value (get-value check)])
+    (debug 2 "operator? ~a ~a\n" check value)
+    (operator? value)))
+
+(define (bound-to-fixture? check)
+  (let ([value (get-value check)])
+    (debug 2 "fixture? ~a ~a\n" check value)
+    (fixture? value)))
+
+(define (bound-to-macro? check)
+  (let ([value (get-value check)])
+    (debug 2 "macro? ~a ~a\n" check value)
+    (honu-transformer? value)))
+
+(define (honu-macro? something)
+  (and (identifier? something)
+       (bound-to-macro? something)))
+
+(define (honu-operator? something)
+  (and (identifier? something)
+       (bound-to-operator? something)))
+
+(define (honu-fixture? something)
+  (and (identifier? something)
+       (bound-to-fixture? something)))
+
+(define (semicolon? what)
+  (define-literal-set check (%semicolon))
+  (define is (and (identifier? what)
+                    ((literal-set->predicate check) what)))
+  (debug "Semicolon? ~a ~a\n" what is)
+  is)
+
+(define (comma? what)
+  (define-literal-set check (honu-comma))
+  (define is (and (identifier? what)
+                    ((literal-set->predicate check) what)))
+  (debug 2 "Comma? ~a ~a\n" what is)
+  is)
+
+(define-literal-set argument-stuff [honu-comma])
+
+(define (stopper? what)
+  (define-literal-set check (honu-comma %semicolon %colon))
+  (define is (and (identifier? what)
+                  ((literal-set->predicate check) what)))
+  (debug 2 "Comma? ~a ~a\n" what is)
+  is)

--- a/enforest/parse.rkt
+++ b/enforest/parse.rkt
@@ -1,8 +1,4 @@
 #lang racket/base
-
-(define-syntax-rule (require-syntax stuff ...)
-                    (require (for-syntax stuff ...)))
-
 ;; phase 0
 (require (for-template racket/base
                        racket/sequence
@@ -11,6 +7,7 @@
          syntax/parse
          syntax/parse/experimental/splicing
          syntax/stx
+         "parse-utils.rkt"
          "compile.rkt"
          "debug.rkt"
          "transformer.rkt"
@@ -26,58 +23,6 @@
 ;; phase -1
 
 (provide parse parse-all do-parse do-macro)
-
-(define (strip-stops code)
-  (define-syntax-class stopper #:literal-sets (cruft)
-    [pattern honu-comma]
-    [pattern %colon]) code)
-
-(define (get-value what)
-  (syntax-local-value what (lambda () #f)))
-
-
-(define (bound-to-operator? check)
-  (let ([value (get-value check)])
-    (debug 2 "operator? ~a ~a\n" check value)
-    (operator? value)))
-
-(define (bound-to-fixture? check)
-  (let ([value (get-value check)])
-    (debug 2 "fixture? ~a ~a\n" check value)
-    (fixture? value)))
-
-(define (bound-to-macro? check)
-  (let ([value (get-value check)])
-    (debug 2 "macro? ~a ~a\n" check value)
-    (honu-transformer? value)))
-
-(define (honu-macro? something)
-  (and (identifier? something)
-       (bound-to-macro? something)))
-
-(define (honu-operator? something)
-  (and (identifier? something)
-       (bound-to-operator? something)))
-
-(define (honu-fixture? something)
-  (and (identifier? something)
-       (bound-to-fixture? something)))
-
-(define (semicolon? what)
-  (define-literal-set check (%semicolon))
-  (define is (and (identifier? what)
-                    ((literal-set->predicate check) what)))
-  (debug "Semicolon? ~a ~a\n" what is)
-  is)
-
-(define (comma? what)
-  (define-literal-set check (honu-comma))
-  (define is (and (identifier? what)
-                    ((literal-set->predicate check) what)))
-  (debug 2 "Comma? ~a ~a\n" what is)
-  is)
-
-(define-literal-set argument-stuff [honu-comma])
 
 (define (parse-arguments arguments)
   (define-syntax-class val
@@ -113,13 +58,6 @@
                       (cons (parse-all-expression parsed) used)
                       used)
                     unparsed))])))))
-
-(define (stopper? what)
-  (define-literal-set check (honu-comma %semicolon %colon))
-  (define is (and (identifier? what)
-                  ((literal-set->predicate check) what)))
-  (debug 2 "Comma? ~a ~a\n" what is)
-  is)
 
 (provide do-parse-rest)
 (define (do-parse-rest stx parse-more)
@@ -217,12 +155,36 @@
   (and (parsed-syntax? code)
        (contains-define? code)))
 
-;; E = macro
-;;   | E operator E
-;;   | [...]
-;;   | f(...)
-;;   | { ... }
-;;   | (...)
+(define-syntax-class atom
+  [pattern x:identifier #:when (not (free-identifier=? #'#%braces #'x))]
+  [pattern x:str]
+  [pattern x:number])
+
+(define (do-macro head rest precedence left current stream)
+  (if current
+      (values (left current) stream)
+      (begin
+        (debug "Honu macro at phase ~a: ~a ~a\n" (syntax-local-phase-level) head (syntax-local-value head))
+        (let-values ([(parsed unparsed terminate?)
+                      ((syntax-local-value head)
+                       (with-syntax ([head head]
+                                     [(rest ...) rest])
+                         (datum->syntax #'head
+                                        (syntax->list #'(head rest ...))
+                                        #'head #'head)))])
+          (with-syntax ([parsed parsed]
+                        [rest unparsed])
+            (debug "Output from macro ~a\n" (pretty-format (syntax->datum #'parsed)))
+            (define re-parse
+              #'parsed)
+            (debug "Reparsed ~a\n" (pretty-format (syntax->datum re-parse)))
+            (define terminate (definition? re-parse))
+            (debug "Terminate? ~a\n" terminate)
+            (if terminate
+                (values (left re-parse)
+                        #'rest)
+                (do-parse #'rest precedence
+                          left re-parse)))))))
 
 ;; 1 + 1
 ;; ^
@@ -249,37 +211,162 @@
 
 ;; parse one form
 ;; return the parsed stuff and the unparsed stuff
-(define (do-macro head rest precedence left current stream)
-  (if current
-      (values (left current) stream)
-      (begin
-        (debug "Honu macro at phase ~a: ~a ~a\n" (syntax-local-phase-level) head (syntax-local-value head))
-        (let-values ([(parsed unparsed terminate?)
-                      ((syntax-local-value head)
-                       (with-syntax ([head head]
-                                     [(rest ...) rest])
-                         (datum->syntax #'head
-                                        (syntax->list #'(head rest ...))
-                                        #'head #'head)))])
-          (with-syntax ([parsed parsed]
-                        [rest unparsed])
-            (debug "Output from macro ~a\n" (pretty-format (syntax->datum #'parsed)))
-            (define re-parse
-              #'parsed)
-            (debug "Reparsed ~a\n" (pretty-format (syntax->datum re-parse)))
-            (define terminate (definition? re-parse))
-            (debug "Terminate? ~a\n" terminate)
-            (if terminate
-                (values (left re-parse)
-                        #'rest)
-                (do-parse #'rest precedence
-                          left re-parse)))))))
-(define (do-parse stream precedence left current)
-  (define-syntax-class atom
-    [pattern x:identifier #:when (not (free-identifier=? #'#%braces #'x))]
-    [pattern x:str]
-    [pattern x:number])
 
+(define (do-operator head rest precedence left current stream)
+  (define operator (syntax-local-value head))
+  (define new-precedence (operator-precedence operator))
+  (define association (operator-association operator))
+  (define binary-transformer (operator-binary-transformer operator))
+  (define unary-transformer (operator-unary-transformer operator))
+  (define postfix? (operator-postfix? operator))
+  (define higher
+    (case association
+      [(left) >]
+      [(right) >=]
+      [else (raise-syntax-error 'parse "invalid associativity. must be either 'left or 'right" association)]))
+  (debug "precedence old ~a new ~a higher? ~a\n" precedence new-precedence (higher new-precedence precedence))
+  (if (higher new-precedence precedence)
+      (let-values ([(parsed unparsed)
+                    (do-parse rest new-precedence
+                              (lambda (stuff)
+                                (define right (parse-all stuff))
+                                (define output
+                                  (if current
+                                      (if binary-transformer
+                                          (binary-transformer (parse-all-expression current) right)
+                                          ;; use a unary transformer in postfix position
+                                          (if (and postfix? unary-transformer)
+                                              (unary-transformer current)
+                                              (error 'binary "cannot be used as a binary operator in ~a" head)))
+                                      (if unary-transformer
+                                          (unary-transformer right)
+                                          (error 'unary "cannot be used as a unary operator in ~a" head))))
+                                (with-syntax ([out (parse-all output)])
+                                  #'out))
+                              #f)])
+        (do-parse unparsed precedence left parsed))
+      ;; if we have a unary transformer then we have to keep parsing
+      (if unary-transformer
+          (if current
+              (if postfix?
+                  (do-parse rest
+                            precedence 
+                            left
+                            (unary-transformer current))
+                  (values (left current) stream))
+              
+              (do-parse rest new-precedence
+                        (lambda (stuff)
+                          (define right (parse-all stuff))
+                          (define output (unary-transformer right))
+                          ;; apply the left function because
+                          ;; we just went ahead with parsing without
+                          ;; caring about precedence
+                          (with-syntax ([out (left (parse-all output))])
+                            #'out))
+                        #f))
+          ;; otherwise we have a binary transformer (or no transformer..??)
+          ;; so we must have made a recursive call to parse, just return the
+          ;; left hand
+          (values (left current) stream))))
+
+(define (do-fun-call head args rest precedence left current stream)
+  (if current
+      ;; FIXME: 9000 is an arbitrary precedence level for
+      ;; function calls
+      (with-syntax ([app (datum->syntax head '#%app)])
+        (if (> precedence 9000)
+            (let ()
+              (debug 2 "higher precedence call ~a\n" current)
+              (define call (with-syntax ([current (left current)]
+                                         [(parsed-args ...)
+                                          (parse-comma-expression args) ])
+                             (racket-syntax (app current parsed-args ...))))
+              (do-parse rest 9000 (lambda (x) x) call))
+            (let ()
+              (debug 2 "function call ~a\n" left)
+              (define call (with-syntax ([current current]
+                                         [(parsed-args ...)
+                                          (parse-comma-expression args) ])
+                             (debug "Parsed args ~a\n" #'(parsed-args ...))
+                             (racket-syntax (app current parsed-args ...))))
+              (do-parse rest precedence left call))))
+      (let ()
+        (debug "inner expression ~a\n" args)
+        (define-values (inner-expression unparsed) (parse args))
+        (when (not (empty-syntax? unparsed))
+          (error 'parse "expression had unparsed elements ~a" unparsed))
+        (do-parse rest precedence left inner-expression))))
+
+(define (do-parse-brackets stuff rest precedence left current stream)
+  (syntax-parse stuff #:literal-sets  (cruft)
+    [(work:honu-expression 
+      %colon (~seq variable:id (~datum =) list:honu-expression (~optional honu-comma)) ...
+      (~seq (~datum where) where:honu-expression (~optional honu-comma)) ...)
+     (define filter (if (attribute where)
+                        #'((#:when where.result) ...)
+                        #'()))
+     (define comprehension
+       (with-syntax ([((filter ...) ...) filter])
+         (racket-syntax (for/list ([variable list.result]
+                                   ...
+                                   filter ... ...)
+                          work.result))))
+     (if current
+         (values (left current) stream)
+         (do-parse rest precedence left comprehension))]
+    [else
+     (debug "Current is ~a\n" current)
+     (define value (with-syntax ([(data ...)
+                                  (parse-comma-expression stuff)])
+                     (debug "Create list from ~a\n" #'(data ...))
+                     (racket-syntax (list data ...))))
+     (define lookup (with-syntax ([(data ...)
+                                   (parse-comma-expression stuff)]
+                                  [current current])
+                      (racket-syntax (sequence-ref current data ...))))
+     (if current
+         (do-parse rest precedence left lookup)
+         (do-parse rest precedence left value))]))
+
+
+;; E = macro
+;;   | E operator E
+;;   | [...]
+;;   | f(...)
+;;   | { ... }
+;;   | (...)
+
+
+(define (do-parse-core head rest stream precedence left current)
+  (syntax-parse stream #:literal-sets (cruft)
+    [body:honu-body
+     (if current
+         (values (left current) stream)
+         (values (left #'body.result) #'()))]
+    [else 
+     (debug "Parse a single thing ~a\n" (syntax->datum #'head))
+     (syntax-parse head #:literal-sets (cruft)
+       [x:atom
+        (debug 2 "atom ~a current ~a\n" #'x current)
+        (if current
+            (values (left current) stream)
+            (do-parse rest precedence left (racket-syntax x)))]
+       ;; [1, 2, 3] -> (list 1 2 3)
+       [(#%brackets stuff ...)
+        (do-parse-brackets #'(stuff ...) rest precedence left current stream)]
+       ;; block of code
+       [body:honu-body
+        (if current
+            (values (left current) stream)
+            (do-parse rest precedence left #'body.result))] 
+       ;; expression or function application
+       [(#%parens args ...)
+        (debug "Maybe function call with ~a\n" #'(args ...))
+        (do-fun-call #'head #'(args ...) rest precedence left current stream)]
+       [else (error 'parser "don't know how to parse ~a" #'head)])]))
+  
+(define (do-parse stream precedence left current)
   (debug "parse ~a precedence ~a left ~a current ~a properties ~a\n"
          (syntax->datum stream) precedence left current
          (syntax-property-symbol-keys stream))
@@ -287,180 +374,44 @@
   (if (parsed-syntax? stream)
       (values (left stream) #'())
       (syntax-parse stream #:literal-sets (cruft)
-                    [((%semicolon inner ...) rest ...)
-                     ;; nothing on the left side should interact with a semicolon
-                     (if current
-                         (values (left current)
-                                 stream)
-                         (begin
-                           (with-syntax ()
-                             (values (left (parse-delayed inner ...))
-                                     #'(rest ...)))))]
-                    [()
-                     (debug "Empty input out: left ~a ~a\n" left (left final))
-                     (values (left final) #'())]
-                    [(head rest ...)
-                     (debug 2 "Not a special expression..\n")
-                     (cond
-                       [(honu-macro? #'head)
-                        (debug "Macro ~a\n" #'head)
-                        (do-macro #'head #'(rest ...) precedence left current stream)]
-                       [(parsed-syntax? #'head)
-                        (debug "Parsed syntax ~a\n" #'head)
-                        (emit-local-step #'head #'head #:id #'do-parse)
-                        (if current
-                            (values current stream)
-                            (do-parse #'(rest ...) precedence left #'head))]
-                       [(honu-fixture? #'head)
-                        (debug 2 "Fixture ~a\n" #'head)
-                        (define transformer (fixture-ref (syntax-local-value #'head) 0))
-                        (define-values (output rest) (transformer current stream))
-                        (do-parse rest precedence left output)]
-                       [(honu-operator? #'head)
-                        (define operator (syntax-local-value #'head))
-
-                        (define new-precedence (operator-precedence operator))
-                        (define association (operator-association operator))
-                        (define binary-transformer (operator-binary-transformer operator))
-                        (define unary-transformer (operator-unary-transformer operator))
-                        (define postfix? (operator-postfix? operator))
-
-                        (define higher
-                          (case association
-                            [(left) >]
-                            [(right) >=]
-                            [else (raise-syntax-error 'parse "invalid associativity. must be either 'left or 'right" association)]))
-                        (debug "precedence old ~a new ~a higher? ~a\n" precedence new-precedence (higher new-precedence precedence))
-                        (if (higher new-precedence precedence)
-                            (let-values ([(parsed unparsed)
-                                          (do-parse #'(rest ...) new-precedence
-                                                    (lambda (stuff)
-                                                      (define right (parse-all stuff))
-                                                      (define output
-                                                        (if current
-                                                            (if binary-transformer
-                                                                (binary-transformer (parse-all-expression current) right)
-                                                                ;; use a unary transformer in postfix position
-                                                                (if (and postfix? unary-transformer)
-                                                                    (unary-transformer current)
-                                                                    (error 'binary "cannot be used as a binary operator in ~a" #'head)))
-                                                            (if unary-transformer
-                                                                (unary-transformer right)
-                                                                (error 'unary "cannot be used as a unary operator in ~a" #'head))))
-                                                      (with-syntax ([out (parse-all output)])
-                                                        #'out))
-
-                                                    #f)])
-                              (do-parse unparsed precedence left parsed))
-                            ;; if we have a unary transformer then we have to keep parsing
-                            (if unary-transformer
-                                (if current
-                                    (if postfix?
-                                        (do-parse #'(rest ...)
-                                                  precedence 
-                                                  left
-                                                  (unary-transformer current))
-                                        (values (left current) stream))
-
-                                    (do-parse #'(rest ...) new-precedence
-                                              (lambda (stuff)
-                                                (define right (parse-all stuff))
-                                                (define output (unary-transformer right))
-                                                ;; apply the left function because
-                                                ;; we just went ahead with parsing without
-                                                ;; caring about precedence
-                                                (with-syntax ([out (left (parse-all output))])
-                                                  #'out))
-                                              #f))
-                                ;; otherwise we have a binary transformer (or no transformer..??)
-                                ;; so we must have made a recursive call to parse, just return the
-                                ;; left hand
-                                (values (left current) stream))
-                            )]
-                       [else
-                        (define-splicing-syntax-class no-left
-                          [pattern (~seq) #:when (and (= precedence 0) (not current))])
-                        (syntax-parse #'(head rest ...) #:literal-sets (cruft)
-                                      [body:honu-body
-                                       (if current
-                                           (values (left current) stream)
-                                           (values (left #'body.result) #'()))]
-                                      [else 
-                                       (debug "Parse a single thing ~a\n" (syntax->datum #'head))
-                                       (syntax-parse #'head
-                                         #:literal-sets (cruft)
-                                         [x:atom
-                                          (debug 2 "atom ~a current ~a\n" #'x current)
-                                          (if current
-                                              (values (left current) stream)
-                                              (do-parse #'(rest ...) precedence left (racket-syntax x)))]
-                                         ;; [1, 2, 3] -> (list 1 2 3)
-                                         [(#%brackets stuff ...)
-                                          (syntax-parse #'(stuff ...) #:literal-sets  (cruft)
-                                                        [(work:honu-expression 
-                                                          %colon (~seq variable:id (~datum =) list:honu-expression (~optional honu-comma)) ...
-                                                          (~seq (~datum where) where:honu-expression (~optional honu-comma)) ...)
-                                                         (define filter (if (attribute where)
-                                                                            #'((#:when where.result) ...)
-                                                                            #'()))
-                                                         (define comprehension
-                                                           (with-syntax ([((filter ...) ...) filter])
-                                                             (racket-syntax (for/list ([variable list.result]
-                                                                                       ...
-                                                                                       filter ... ...)
-                                                                              work.result))))
-                                                         (if current
-                                                             (values (left current) stream)
-                                                             (do-parse #'(rest ...) precedence left comprehension))]
-                                                        [else
-                                                         (debug "Current is ~a\n" current)
-                                                         (define value (with-syntax ([(data ...)
-                                                                                      (parse-comma-expression #'(stuff ...))])
-                                                                         (debug "Create list from ~a\n" #'(data ...))
-                                                                         (racket-syntax (list data ...))))
-                                                         (define lookup (with-syntax ([(data ...)
-                                                                                       (parse-comma-expression #'(stuff ...))]
-                                                                                      [current current])
-                                                                          (racket-syntax (sequence-ref current data ...))))
-                                                         (if current
-                                                             (do-parse #'(rest ...) precedence left lookup)
-                                                             (do-parse #'(rest ...) precedence left value))])]
-                                         ;; block of code
-                                         [body:honu-body
-                                          (if current
-                                              (values (left current) stream)
-                                              (do-parse #'(rest ...) precedence left #'body.result))] 
-                                         ;; expression or function application
-                                         [(#%parens args ...)
-                                          (debug "Maybe function call with ~a\n" #'(args ...))
-                                          (if current
-                                              ;; FIXME: 9000 is an arbitrary precedence level for
-                                              ;; function calls
-                                              (with-syntax ([app (datum->syntax #'head '#%app)])
-                                                (if (> precedence 9000)
-                                                    (let ()
-                                                      (debug 2 "higher precedence call ~a\n" current)
-                                                      (define call (with-syntax ([current (left current)]
-                                                                                 [(parsed-args ...)
-                                                                                  (parse-comma-expression #'(args ...)) ])
-                                                                     (racket-syntax (app current parsed-args ...))))
-                                                      (do-parse #'(rest ...) 9000 (lambda (x) x) call))
-                                                    (let ()
-                                                      (debug 2 "function call ~a\n" left)
-                                                      (define call (with-syntax ([current current]
-                                                                                 [(parsed-args ...)
-                                                                                  (parse-comma-expression #'(args ...)) ])
-                                                                     (debug "Parsed args ~a\n" #'(parsed-args ...))
-                                                                     (racket-syntax (app current parsed-args ...))))
-                                                      (do-parse #'(rest ...) precedence left call))))
-                                              (let ()
-                                                (debug "inner expression ~a\n" #'(args ...))
-                                                (define-values (inner-expression unparsed) (parse #'(args ...)))
-                                                (when (not (empty-syntax? unparsed))
-                                                  (error 'parse "expression had unparsed elements ~a" unparsed))
-                                                (do-parse #'(rest ...) precedence left inner-expression)))]
-                                         [else (error 'parser "don't know how to parse ~a" #'head)])])])])))
-
+        [((%semicolon inner ...) rest ...)
+         ;; nothing on the left side should interact with a semicolon
+         (if current
+             (values (left current) stream)
+             (begin
+               (with-syntax ()
+                 (values (left (parse-delayed inner ...)) #'(rest ...)))))]
+        [()
+         (debug "Empty input out: left ~a ~a\n" left (left final))
+         (values (left final) #'())]
+        [(head rest ...)
+         (debug 2 "Not a special expression..\n")
+         (cond
+           [(honu-macro? #'head)
+            (debug "Macro ~a\n" #'head)
+            (do-macro #'head #'(rest ...) precedence left current stream)]
+           [(parsed-syntax? #'head)
+            (debug "Parsed syntax ~a\n" #'head)
+            (emit-local-step #'head #'head #:id #'do-parse)
+            (if current
+                (values current stream)
+                (do-parse #'(rest ...) precedence left #'head))]
+           [(honu-fixture? #'head)
+            (debug 2 "Fixture ~a\n" #'head)
+            (define transformer (fixture-ref (syntax-local-value #'head) 0))
+            (define-values (output rest) (transformer current stream))
+            (do-parse rest precedence left output)]
+           [(honu-operator? #'head)
+            (do-operator #'head #'(rest ...) precedence left current stream)]
+           [else
+            (define-splicing-syntax-class no-left
+              [pattern (~seq) #:when (and (= precedence 0) (not current))])
+            (syntax-parse #'(head rest ...) #:literal-sets (cruft)
+              [body:honu-body
+               (if current
+                   (values (left current) stream)
+                   (values (left #'body.result) #'()))]
+              [else (do-parse-core #'head #'(rest ...) stream precedence left current)])])])))
 
 
 (define (parse input)

--- a/enforest/transformer.rkt
+++ b/enforest/transformer.rkt
@@ -1,7 +1,6 @@
 #lang racket/base
 (require racket/syntax)
 
-
 (provide honu-transformer? make-honu-transformer honu-trans-ref)
 
 (define-values (prop:honu-transformer honu-transformer? honu-transformer-ref)
@@ -41,8 +40,7 @@
                                         (op-fn #'l))]
                                      [(_ l r ...)
                                       (let ([op-fn (operator-binary-transformer self)])
-                                        (apply op-fn (cons #'l (syntax->list #'(r ...)))))]
-                                     ))))
+                                        (apply op-fn (cons #'l (syntax->list #'(r ...)))))]))))
 
 (define (get n)
   (lambda (operator)

--- a/honu/core/main.rkt
+++ b/honu/core/main.rkt
@@ -3,6 +3,7 @@
 (define-syntax-rule (standard-honu meta-level)
   (begin
     (require (for-meta meta-level
+                       (only-in racket/base #%app)
                        racket/base
                        racket/class
                        (prefix-in list: racket/list)
@@ -107,6 +108,7 @@
                        mergeSyntax
                        this
                        error
+                       #%app
                        #%top
                        #%datum
                        (... ...)


### PR DESCRIPTION
Moving parts of do-parse into 
-  do-parse-operator 
-  do-parse-brackets
-  do-parse-fun-call
-  do-parse-core
  alleviating some right-ward drift, and subjectively improving readability.
