### PR TITLE
syntax-parse honu-comma as a datum-literal

### DIFF
--- a/honu-parse/parse.rkt
+++ b/honu-parse/parse.rkt
@@ -75,7 +75,7 @@
                [rest arguments])
       (if (empty-syntax? rest)
         (reverse used)
-        (syntax-parse rest   #:literals (honu-comma)
+        (syntax-parse rest   #:datum-literals (honu-comma)
           [(honu-comma more ...)
            (loop used #'(more ...))]
           [else


### PR DESCRIPTION
Honu is broken for Racket v6.4 and greater.  This small patch fixes it for Racket v7.0 and lower.  There are more things broken in Racket v7.1.